### PR TITLE
Fix action being broken since Ruby 4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #     $ docker push jeantessier/test-summary-action:latest
 #
 
-FROM ruby:latest
+FROM ruby:3.4.2
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1


### PR DESCRIPTION
Hi ! It seems the action would not build since ruby 4.0.0 docker image got released
I do not know ruby so I cannot upgrade to make it work for 4.0.0  

So this pr is made to force docker to use the expected ruby version as a (temporary ?) solution